### PR TITLE
Add logging library

### DIFF
--- a/inc/Core/log.hpp
+++ b/inc/Core/log.hpp
@@ -18,7 +18,7 @@ class Log
     } level;
 
   private:
-    const std::string path = "../log/";
+    const std::string path = "../../log/";
     std::ofstream fout;
     const std::time_t m_startTime;
 


### PR DESCRIPTION
Done! There must be folder called "log" at Cengaver directory for this to work.
We can increase our logging precision with c++20, for chrono.